### PR TITLE
feat: 实现 Desktop 资源获取与详情展示功能

### DIFF
--- a/src-tauri/src/commands/desktop.rs
+++ b/src-tauri/src/commands/desktop.rs
@@ -46,7 +46,6 @@ pub struct WindowDetail {
 #[tauri::command]
 pub async fn get_desktop(
     state: State<'_, AppState>,
-    _size: Option<String>,
     uri: Option<String>,
 ) -> Result<Vec<DesktopWindow>, String> {
     let lock = state.manager.read().await;

--- a/src/components/DesktopResources/index.tsx
+++ b/src/components/DesktopResources/index.tsx
@@ -29,7 +29,7 @@ export function DesktopResources() {
 
   // Show error message when detail fetch fails
   useEffect(() => {
-    Object.entries(detailErrors).forEach(([err]) => {
+    Object.entries(detailErrors).forEach(([_uri, err]) => {
       if (err) {
         message.error(`${t('desktop.failedToLoadDetail')}: ${err}`);
       }
@@ -107,7 +107,7 @@ export function DesktopResources() {
             </Text>
             <div style={{ marginTop: 4 }}>
               <Text type="secondary">
-                [{t('desktop.binaryData')}: {content.blob?.length || 0} bytes]
+                [{t('desktop.binaryData')}: {Math.floor((content.blob?.length || 0) * 3 / 4)} bytes]
               </Text>
             </div>
           </div>
@@ -188,7 +188,7 @@ export function DesktopResources() {
             onExpand: handleRowExpand,
             expandedRowRender: (record) => {
               const detail = windowDetails[record.uri];
-              const isLoading = loadingDetails.has(record.uri);
+              const isLoading = loadingDetails[record.uri];
 
               if (isLoading) {
                 return (

--- a/src/stores/desktopStore.ts
+++ b/src/stores/desktopStore.ts
@@ -31,10 +31,10 @@ interface DesktopState {
 
   // Window detail states
   windowDetails: Record<string, WindowDetail>;
-  loadingDetails: Set<string>;
+  loadingDetails: Record<string, boolean>;
   detailErrors: Record<string, string>;
 
-  fetchDesktop: (size?: string, uri?: string) => Promise<void>;
+  fetchDesktop: (uri?: string) => Promise<void>;
   fetchWindowDetail: (server: string, uri: string) => Promise<void>;
   reset: () => void;
 }
@@ -44,20 +44,19 @@ const initialState = {
   loading: false,
   error: null as string | null,
   windowDetails: {} as Record<string, WindowDetail>,
-  loadingDetails: new Set<string>(),
+  loadingDetails: {} as Record<string, boolean>,
   detailErrors: {} as Record<string, string>,
 };
 
-export const useDesktopStore = create<DesktopState>((set, get) => ({
+export const useDesktopStore = create<DesktopState>((set) => ({
   ...initialState,
 
   reset: () => set(initialState),
 
-  fetchDesktop: async (size?: string, uri?: string) => {
+  fetchDesktop: async (uri?: string) => {
     set({ loading: true, error: null });
     try {
       const windows = await invoke<DesktopWindow[]>('get_desktop', {
-        size: size ?? null,
         uri: uri ?? null,
       });
       set({ windows, loading: false });
@@ -67,39 +66,33 @@ export const useDesktopStore = create<DesktopState>((set, get) => ({
   },
 
   fetchWindowDetail: async (server: string, uri: string) => {
-    // Add to loading set
+    // Add to loading record
     set((state) => ({
-      loadingDetails: new Set(state.loadingDetails).add(uri),
+      loadingDetails: { ...state.loadingDetails, [uri]: true },
     }));
-
-    // Clear previous error for this uri
-    const { detailErrors } = get();
-    const newErrors = { ...detailErrors };
-    delete newErrors[uri];
 
     try {
       const detail = await invoke<WindowDetail>('get_window_detail', {
         serverName: server,
         uri,
       });
-      set((state) => ({
-        windowDetails: { ...state.windowDetails, [uri]: detail },
-        loadingDetails: (() => {
-          const next = new Set(state.loadingDetails);
-          next.delete(uri);
-          return next;
-        })(),
-        detailErrors: newErrors,
-      }));
+      set((state) => {
+        const { [uri]: _, ...remainingLoading } = state.loadingDetails;
+        const { [uri]: __, ...remainingErrors } = state.detailErrors;
+        return {
+          windowDetails: { ...state.windowDetails, [uri]: detail },
+          loadingDetails: remainingLoading,
+          detailErrors: remainingErrors,
+        };
+      });
     } catch (e) {
-      set((state) => ({
-        loadingDetails: (() => {
-          const next = new Set(state.loadingDetails);
-          next.delete(uri);
-          return next;
-        })(),
-        detailErrors: { ...state.detailErrors, [uri]: String(e) },
-      }));
+      set((state) => {
+        const { [uri]: _, ...remainingLoading } = state.loadingDetails;
+        return {
+          loadingDetails: remainingLoading,
+          detailErrors: { ...state.detailErrors, [uri]: String(e) },
+        };
+      });
     }
   },
 }));

--- a/src/test/components/DesktopResources.test.tsx
+++ b/src/test/components/DesktopResources.test.tsx
@@ -10,14 +10,14 @@ const mockStore = {
   loading: false,
   error: null as string | null,
   windowDetails: {} as Record<string, import('@/stores/desktopStore').WindowDetail>,
-  loadingDetails: new Set<string>(),
+  loadingDetails: {} as Record<string, boolean>,
   detailErrors: {} as Record<string, string>,
   fetchDesktop: mockFetchDesktop,
   fetchWindowDetail: mockFetchWindowDetail,
   reset: vi.fn(),
 };
 
- vi.mock('@/stores/desktopStore', () => ({
+vi.mock('@/stores/desktopStore', () => ({
   useDesktopStore: vi.fn(() => mockStore),
 }));
 
@@ -242,7 +242,7 @@ describe('DesktopResources', () => {
     mockUseDesktopStore.mockReturnValue({
       ...mockStore,
       windows: mockWindows,
-      loadingDetails: new Set(['window://main']),
+      loadingDetails: { 'window://main': true },
     } as any);
     render(<DesktopResources />);
 

--- a/src/test/stores/desktopStore.test.ts
+++ b/src/test/stores/desktopStore.test.ts
@@ -5,11 +5,7 @@ const mockedInvoke = vi.mocked(invoke);
 
 describe('desktopStore', () => {
   beforeEach(() => {
-    useDesktopStore.setState({
-      windows: [],
-      loading: false,
-      error: null,
-    });
+    useDesktopStore.getState().reset();
     mockedInvoke.mockReset();
   });
 
@@ -23,19 +19,17 @@ describe('desktopStore', () => {
       await useDesktopStore.getState().fetchDesktop();
 
       expect(mockedInvoke).toHaveBeenCalledWith('get_desktop', {
-        size: null,
         uri: null,
       });
       expect(useDesktopStore.getState().windows).toEqual(mockWindows);
     });
 
-    it('passes size and uri parameters', async () => {
+    it('passes uri parameter', async () => {
       mockedInvoke.mockResolvedValueOnce([]);
 
-      await useDesktopStore.getState().fetchDesktop('large', 'window://test');
+      await useDesktopStore.getState().fetchDesktop('window://test');
 
       expect(mockedInvoke).toHaveBeenCalledWith('get_desktop', {
-        size: 'large',
         uri: 'window://test',
       });
     });
@@ -70,12 +64,78 @@ describe('desktopStore', () => {
     });
   });
 
+  describe('fetchWindowDetail', () => {
+    it('populates window detail on success', async () => {
+      const mockDetail = {
+        uri: 'window://main',
+        title: null,
+        server: 'desktop-server',
+        contents: [{ type: 'text', uri: 'window://main', text: 'Hello' }],
+      };
+      mockedInvoke.mockResolvedValueOnce(mockDetail);
+
+      await useDesktopStore.getState().fetchWindowDetail('desktop-server', 'window://main');
+
+      expect(mockedInvoke).toHaveBeenCalledWith('get_window_detail', {
+        serverName: 'desktop-server',
+        uri: 'window://main',
+      });
+      expect(useDesktopStore.getState().windowDetails['window://main']).toEqual(mockDetail);
+    });
+
+    it('sets detailErrors on failure', async () => {
+      mockedInvoke.mockRejectedValueOnce('detail not found');
+
+      await useDesktopStore.getState().fetchWindowDetail('server', 'window://fail');
+
+      expect(useDesktopStore.getState().detailErrors['window://fail']).toBe('detail not found');
+    });
+
+    it('sets loadingDetails during fetch', async () => {
+      let resolveFn!: (value: unknown) => void;
+      const promise = new Promise((resolve) => {
+        resolveFn = resolve;
+      });
+      mockedInvoke.mockReturnValueOnce(promise as any);
+
+      const fetchPromise = useDesktopStore.getState().fetchWindowDetail('server', 'window://loading');
+
+      expect(useDesktopStore.getState().loadingDetails['window://loading']).toBe(true);
+
+      resolveFn({ uri: 'window://loading', server: 'server', contents: [] });
+      await fetchPromise;
+
+      expect(useDesktopStore.getState().loadingDetails['window://loading']).toBeUndefined();
+    });
+
+    it('clears previous error for uri on success', async () => {
+      // Set an existing error
+      useDesktopStore.setState({
+        detailErrors: { 'window://main': 'old error' },
+      });
+
+      const mockDetail = {
+        uri: 'window://main',
+        server: 'server',
+        contents: [],
+      };
+      mockedInvoke.mockResolvedValueOnce(mockDetail);
+
+      await useDesktopStore.getState().fetchWindowDetail('server', 'window://main');
+
+      expect(useDesktopStore.getState().detailErrors['window://main']).toBeUndefined();
+    });
+  });
+
   describe('reset', () => {
     it('resets all state to initial values', () => {
       useDesktopStore.setState({
         windows: [{ uri: 'window://1', title: 'Test', server: 'desktop' }],
         loading: true,
         error: 'some error',
+        windowDetails: { 'window://1': { uri: 'window://1', server: 'desktop', contents: [] } },
+        loadingDetails: { 'window://1': true },
+        detailErrors: { 'window://1': 'error' },
       });
 
       useDesktopStore.getState().reset();
@@ -83,6 +143,9 @@ describe('desktopStore', () => {
       expect(useDesktopStore.getState().windows).toEqual([]);
       expect(useDesktopStore.getState().loading).toBe(false);
       expect(useDesktopStore.getState().error).toBeNull();
+      expect(useDesktopStore.getState().windowDetails).toEqual({});
+      expect(useDesktopStore.getState().loadingDetails).toEqual({});
+      expect(useDesktopStore.getState().detailErrors).toEqual({});
     });
   });
 });


### PR DESCRIPTION
## Summary
- 实现 `get_desktop` 命令，支持按 URI 过滤桌面窗口资源列表
- 新增 `get_window_detail` 命令，获取窗口内容详情（文本/图片/二进制）
- 前端 DesktopResources 组件支持窗口列表展示与行展开查看详情
- desktopStore 新增 `fetchWindowDetail` 方法管理详情加载状态
- 升级 smcp-computer 依赖至 0.1.11
- 修复 code review 反馈：移除多余参数、修复类型序列化、完善测试覆盖

## Test plan
- [x] Rust 后端 16 个单元测试 + contract tests 通过
- [x] 前端组件测试和 store 测试通过
- [ ] E2E 测试验证桌面资源页面交互

🤖 Generated with [Claude Code](https://claude.com/claude-code)