### PR TITLE
feat: 实现桌面资源窗口详情获取功能

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,6 +32,15 @@ jobs:
             librsvg2-dev \
             patchelf
 
+      # Build frontend (Tauri needs ../dist to exist)
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+
       - name: Run benchmarks
         working-directory: src-tauri
         run: cargo bench --bench benchmarks -- --output-format bencher | tee output.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,8 +154,6 @@ jobs:
           workspaces: src-tauri
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3666,7 +3666,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3971,7 +3971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4640,7 +4640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6045,9 +6045,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smcp"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee20efcbd280f0f524188f9acbab86b8455da3bc415f8ef8f5bcc28f79fc8ea"
+checksum = "fc8b2ed814f1a2ea7d1b56142183435f5a93b8576b51007038ead0c740faf623"
 dependencies = [
  "serde",
  "serde_json",
@@ -6057,9 +6057,9 @@ dependencies = [
 
 [[package]]
 name = "smcp-computer"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e3b0370cd6d126aca1e424fa251120d3ad392b958d099475eb6becd56a6caf"
+checksum = "d5c4f1fc0e39807f18908bb985164a5080a390e2db9c8cf8ecbf09d0768bc8af"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-updater = "2"
 
 # A2C-SMCP Computer implementation
-smcp-computer = "0.1.11"
+smcp-computer = "0.1.12"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- 实现 `get_desktop` 和 `get_window_detail` Tauri 命令，支持按 URI 过滤窗口资源并获取窗口内容详情
- 前端 DesktopResources 组件支持窗口详情展示，desktopStore 新增 fetchWindowDetail 方法
- 升级 smcp-computer 至 0.1.12，修复上游 Socket.IO 通道 `handle_get_desktop_with_ack` 返回空列表的问题 (Closes #17)
- 修复 CI 流水线 pnpm 版本冲突和 Benchmarks 编译失败

## Test plan
- [x] Rust 后端 83 个测试全部通过（含 14 个 contract tests + 16 个集成测试）
- [x] 前端 143 个测试全部通过
- [ ] 启动应用连接 SMCP 服务器，验证桌面资源窗口列表正常展示
- [ ] 通过外部 Agent 发送 `get_desktop` Socket.IO 请求，确认返回非空窗口数据

🤖 Generated with [Claude Code](https://claude.com/claude-code)