### PR TITLE
fix: close SMCP connections during lifecycle changes

### DIFF
--- a/docs/proposals/tfrm-16-rust-sdk-handshake-config.md
+++ b/docs/proposals/tfrm-16-rust-sdk-handshake-config.md
@@ -12,7 +12,7 @@
 
 > **状态：已实现 + 已验收**（更新于 2026-04-25）
 > - rust-sdk @ workspace 0.1.15，`SmcpComputerClientBuilder` + 默认 `access_token` + Agent 对称修改全部到位
-> - tfrobot-client 侧验收：7/7 acceptance tests pass（`cargo test --test smcp_handshake_config_test --features verify-smcp-0-1-15`）
+> - tfrobot-client 侧验收：7/7 acceptance tests pass（当前 feature：`cargo test --test smcp_handshake_config_test --features verify-smcp-0-2-2`）
 > - TFRM-16 Jira 不关闭：仍待 UI 改造、Manager 集成、指数退避、跨 SDK 协议版本对齐 4 项子任务（见 §5 非目标）
 
 ---
@@ -262,16 +262,16 @@ version = "0.1.15"  # was 0.1.14
 
 ## 6. 验收方式
 
-tfrobot-client 侧已提交验收测试用例 `src-tauri/tests/smcp_handshake_config_test.rs`，由 Cargo feature `verify-smcp-0-1-15` 门控（默认关闭，不影响现有 CI）。
+tfrobot-client 侧已提交验收测试用例 `src-tauri/tests/smcp_handshake_config_test.rs`，由 Cargo feature `verify-smcp-0-2-2` 门控（默认关闭，不影响现有 CI）。
 
 **验收流程**（rust-sdk 工程师完成实现后）：
 
-1. rust-sdk 发布 `smcp-computer` v0.1.15 到 crates.io。
-2. tfrobot-client 维护者在 `src-tauri/Cargo.toml` 将 `smcp-computer` 升级到 `0.1.15`。
+1. rust-sdk 发布 `smcp-computer` v0.2.2 到 crates.io。
+2. tfrobot-client 维护者在 `src-tauri/Cargo.toml` 将 `smcp-computer` 升级到 `0.2.2`。
 3. 运行：
    ```bash
    cd /Users/jqq/RustroverProjects/tfrobot-client/src-tauri
-   cargo test --test smcp_handshake_config_test --features verify-smcp-0-1-15
+   cargo test --test smcp_handshake_config_test --features verify-smcp-0-2-2
    ```
 4. 7 个用例全绿 → 在 TFRM-16 评论区确认验收通过。
 5. TFRM-16 **不关闭**（还有 UI、Manager 集成等未完成子项）。

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1283,6 +1283,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,6 +1609,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
+name = "engineioxide"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a36d7cb810f4501c85c13211064288cdc870742a072005de2851096d4956acb6"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "engineioxide-core",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite 0.26.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "engineioxide-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6512b1bc8dfb74d61b55878d712082be39a960abee8590f310723587de343e"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "rand 0.9.2",
+ "serde",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,6 +1788,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "fdeflate"
@@ -1879,6 +1950,15 @@ checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
 dependencies = [
  "lazy_static",
  "num",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2104,6 +2184,19 @@ dependencies = [
  "libc",
  "system-deps",
  "x11",
+]
+
+[[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.48.0",
 ]
 
 [[package]]
@@ -2338,7 +2431,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2357,7 +2450,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2413,6 +2506,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -2594,6 +2693,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -2684,6 +2784,7 @@ dependencies = [
  "socket2 0.6.3",
  "system-configuration",
  "tokio",
+ "tower-layer",
  "tower-service",
  "tracing",
  "windows-registry",
@@ -2850,12 +2951,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2889,6 +2990,26 @@ dependencies = [
  "nom 7.1.3",
  "smallvec",
  "snafu 0.7.5",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3141,8 +3262,33 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
+ "dbus-secret-service",
  "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
 ]
 
 [[package]]
@@ -3153,7 +3299,7 @@ checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
  "cssparser 0.29.6",
  "html5ever 0.29.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "selectors 0.24.0",
 ]
 
@@ -3231,6 +3377,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3294,6 +3449,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3351,10 +3521,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f926ade0c4e170215ae43342bf13b9310a437609c81f29f86c5df6657582ef9"
 
 [[package]]
 name = "md-5"
@@ -3416,6 +3601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -3564,6 +3750,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
 dependencies = [
  "nom 8.0.0",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4154,7 +4376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -4424,7 +4646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "quick-xml",
  "serde",
  "time",
@@ -4617,11 +4839,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
 dependencies = [
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "nix",
  "tokio",
  "tracing",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5048,7 +5270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c11639076bf147be211b90e47790db89f4c22b6c8a9ca6e960833869da67166"
 dependencies = [
  "aho-corasick",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.13.0",
  "nohash",
  "regex",
@@ -5313,6 +5535,25 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -5622,6 +5863,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5843,7 +6090,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -5870,7 +6117,20 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -5962,6 +6222,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_child"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6044,42 +6313,74 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smcp"
-version = "0.1.15"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7c6157dd336a81505481e5e098ef88f1758040cb8fd5e5caad5932c5d3c2f2"
+checksum = "b5d83f198c63c2f9e4d1471127294f80f9a8a998ad259a5f7a6f04d56f7c2a91"
 dependencies = [
+ "base64 0.22.1",
+ "futures",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
+ "url",
  "uuid",
 ]
 
 [[package]]
-name = "smcp-computer"
-version = "0.1.15"
+name = "smcp-client-transport"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8794a8160047e1d2b03743e9552df01852677f5a87f3595cfa656ffc98c9dbc"
+checksum = "f1ffb0f26a4ce16bd60a9f0b7e8a6e70f9013cbf8eb785da7cc70f8f4f94653b"
+dependencies = [
+ "serde_json",
+ "smcp",
+ "tf-rust-engineio",
+ "tf-rust-socketio",
+ "tracing",
+]
+
+[[package]]
+name = "smcp-computer"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b44f3e3f6cb996e9e1c6d21eb8756bd4a8e3149fa8030e42f83dea1e1e314be5"
 dependencies = [
  "async-recursion",
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "dashmap",
  "dirs",
  "eventsource-client",
+ "fd-lock",
+ "flate2",
  "futures",
  "futures-util",
+ "indexmap 2.14.0",
+ "keyring",
  "lazy_static",
+ "notify",
  "percent-encoding",
+ "plist",
  "regex",
  "reqwest 0.12.28",
  "rmcp",
+ "rmp-serde",
  "rpassword",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
+ "sha2",
  "smcp",
+ "smcp-client-transport",
+ "tar",
  "tf-rust-socketio",
  "thiserror 2.0.18",
  "tokio",
@@ -6088,6 +6389,8 @@ dependencies = [
  "url",
  "uuid",
  "vrl",
+ "winreg",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -6160,6 +6463,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "socketioxide"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22bbd5602e94b08333c98a2f31ab7df6dced9f38562ff03aa671db1936e2f112"
+dependencies = [
+ "bytes",
+ "engineioxide",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
+ "matchit",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "socketioxide-core",
+ "socketioxide-parser-common",
+ "state",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "socketioxide-core"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93414eb4c54a5fd9dddc1fb80b56a00a3b0cbec60f5d7e3c479ccea73ac258b0"
+dependencies = [
+ "arbitrary",
+ "bytes",
+ "engineioxide-core",
+ "futures-core",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "socketioxide-parser-common"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9847d1b4ee0e5d419c78a9a3f29b204aeb0970303595fc24be045f244f076938"
+dependencies = [
+ "bytes",
+ "itoa",
+ "serde",
+ "serde_json",
+ "socketioxide-core",
+]
+
+[[package]]
 name = "softbuffer"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6225,6 +6582,15 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "state"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8c4a4445d81357df8b1a650d0d0d6fbbbfe99d064aa5e02f3e4022061476d8"
+dependencies = [
+ "loom",
+]
 
 [[package]]
 name = "string_cache"
@@ -6431,7 +6797,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -6456,9 +6822,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -6519,7 +6885,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6730,7 +7096,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -6755,7 +7121,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6780,7 +7146,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -6877,9 +7243,9 @@ dependencies = [
 
 [[package]]
 name = "tf-rust-engineio"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e34149fcb6a0790edd3bd1f8cc463c1722ad39be82df8b657ca2df179744366"
+checksum = "86c6ddbc7f08807da7c7604e452943de6c248406e0d73258e30c506b5fc79323"
 dependencies = [
  "adler32",
  "async-stream",
@@ -6894,16 +7260,16 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tokio-tungstenite",
- "tungstenite",
+ "tokio-tungstenite 0.21.0",
+ "tungstenite 0.21.0",
  "url",
 ]
 
 [[package]]
 name = "tf-rust-socketio"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4a973c57c7158d0392cc7f6544da63220f0253e7a11ae6d225b0136c3f133e"
+checksum = "dc40a5f3adf357af456b0046fce9ebcd584e6a7eac08186d0661429496b9b339"
 dependencies = [
  "adler32",
  "async-stream",
@@ -6932,6 +7298,9 @@ dependencies = [
  "dirs",
  "filetime",
  "hex",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
  "keyring",
  "log",
  "reqwest 0.12.28",
@@ -6940,6 +7309,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smcp-computer",
+ "socketioxide",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -6950,6 +7320,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tower",
  "which",
 ]
 
@@ -6991,6 +7362,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -7151,7 +7531,19 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
- "tungstenite",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.26.2",
 ]
 
 [[package]]
@@ -7185,7 +7577,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.0.4",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -7227,7 +7619,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -7238,7 +7630,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
@@ -7251,7 +7643,7 @@ version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow 0.7.15",
@@ -7347,6 +7739,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -7398,10 +7820,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -7602,6 +8047,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "value-bag"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7666,7 +8117,7 @@ dependencies = [
  "hostname",
  "iana-time-zone",
  "idna",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "indoc",
  "influxdb-line-protocol",
  "ipcrypt-rs",
@@ -7885,7 +8336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -7939,7 +8390,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -8045,7 +8496,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -8069,7 +8520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -8129,6 +8580,15 @@ dependencies = [
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
+]
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -8343,6 +8803,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -8400,6 +8875,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -8418,6 +8899,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -8433,6 +8920,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8466,6 +8959,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -8481,6 +8980,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8502,6 +9007,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -8517,6 +9028,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8592,7 +9109,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -8623,7 +9140,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -8642,7 +9159,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -8706,7 +9223,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -8888,6 +9405,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -8930,8 +9461,22 @@ checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
+ "zopfli",
 ]
 
 [[package]]
@@ -8945,6 +9490,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -76,6 +76,6 @@ harness = false
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
-# Enable TFRM-16 acceptance tests against smcp-computer >= 0.1.15.
+# Enable TFRM-16 acceptance tests against smcp-computer >= 0.2.2.
 # See docs/proposals/tfrm-16-rust-sdk-handshake-config.md.
-verify-smcp-0-1-15 = []
+verify-smcp-0-2-2 = []

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-updater = "2"
 
 # A2C-SMCP Computer implementation
-smcp-computer = "0.1.15"
+smcp-computer = "0.2.2"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -63,6 +63,11 @@ hex = "0.4"
 tempfile = "3"
 filetime = "0.2"
 criterion = { version = "0.5", features = ["async_tokio"] }
+http-body-util = "0.1"
+hyper = { version = "1", features = ["server", "http1", "full"] }
+hyper-util = { version = "0.1", features = ["tokio", "service", "full"] }
+socketioxide = { version = "0.16.3", features = ["state"] }
+tower = { version = "0.5", features = ["util"] }
 
 [[bench]]
 name = "benchmarks"

--- a/src-tauri/src/commands/config_io.rs
+++ b/src-tauri/src/commands/config_io.rs
@@ -168,6 +168,7 @@ fn build_stdio_config(name: &str, server: &ClaudeDesktopServer) -> MCPServerConf
         tool_meta: HashMap::new(),
         default_tool_meta: None,
         vrl: None,
+        env_file: None,
         server_parameters: StdioServerParameters {
             command: server.command.clone(),
             args: server.args.clone(),

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -1,6 +1,9 @@
 use crate::AppState;
 use serde::{Deserialize, Serialize};
 use tauri::State;
+use tokio::time::{timeout, Duration};
+
+const SMCP_CONNECTION_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Connection Profile stored to disk (API Key stored separately in Keychain)
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -97,6 +100,10 @@ pub async fn delete_profile(state: State<'_, AppState>, name: String) -> Result<
 /// Connect to SMCP server using a saved profile
 #[tauri::command]
 pub async fn connect_smcp(state: State<'_, AppState>, profile_name: String) -> Result<(), String> {
+    connect_smcp_core(&state, profile_name).await
+}
+
+pub async fn connect_smcp_core(state: &AppState, profile_name: String) -> Result<(), String> {
     log::info!("Connecting with profile: {}", profile_name);
 
     let profiles = state.config.load_profiles().map_err(|e| e.to_string())?;
@@ -126,20 +133,27 @@ pub async fn connect_smcp(state: State<'_, AppState>, profile_name: String) -> R
     .await
     .map_err(|e| e.to_string())?;
 
-    client
-        .join_office(&profile.office_id)
-        .await
-        .map_err(|e| e.to_string())?;
+    if let Err(e) = client.join_office(&profile.office_id).await {
+        disconnect_smcp_client(client, "after join_office failure").await;
+        return Err(e.to_string());
+    }
 
-    let mut conn = state.connection.write().await;
-    *conn = Some(ConnectionState {
-        client: std::sync::Arc::new(client),
+    let new_connection = ConnectionState {
+        client,
         profile_name: profile.name.clone(),
         url: profile.url.clone(),
         office_id: profile.office_id.clone(),
         computer_name: profile.computer_name.clone(),
         connected_at: chrono::Utc::now(),
-    });
+    };
+
+    let previous_connection = {
+        let mut conn = state.connection.write().await;
+        conn.replace(new_connection)
+    };
+    if let Some(connection) = previous_connection {
+        close_smcp_connection(connection).await;
+    }
 
     log::info!("Connected to SMCP server: {}", profile.url);
     let _ = state.log_service.write(
@@ -154,19 +168,61 @@ pub async fn connect_smcp(state: State<'_, AppState>, profile_name: String) -> R
 /// Disconnect from SMCP server
 #[tauri::command]
 pub async fn disconnect_smcp(state: State<'_, AppState>) -> Result<(), String> {
+    disconnect_smcp_core(&state).await
+}
+
+pub async fn disconnect_smcp_core(state: &AppState) -> Result<(), String> {
     log::info!("Disconnecting from SMCP server");
 
-    let mut conn = state.connection.write().await;
-    if let Some(connection) = conn.take() {
-        if let Err(e) = connection.client.leave_office(&connection.office_id).await {
-            log::warn!("Error leaving office: {}", e);
-        }
+    let existing_connection = {
+        let mut conn = state.connection.write().await;
+        conn.take()
+    };
+    if let Some(connection) = existing_connection {
+        close_smcp_connection(connection).await;
     }
 
     let _ = state
         .log_service
         .write("info", "connection", "Disconnected from SMCP server", None);
     Ok(())
+}
+
+pub async fn close_smcp_connection(connection: ConnectionState) {
+    let ConnectionState {
+        client, office_id, ..
+    } = connection;
+
+    match timeout(
+        SMCP_CONNECTION_CLOSE_TIMEOUT,
+        client.leave_office(&office_id),
+    )
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => log::warn!("Error leaving office: {}", e),
+        Err(_) => log::warn!(
+            "Timed out leaving SMCP office after {:?}",
+            SMCP_CONNECTION_CLOSE_TIMEOUT
+        ),
+    }
+
+    disconnect_smcp_client(client, "from SMCP server").await;
+}
+
+async fn disconnect_smcp_client(
+    client: smcp_computer::socketio_client::SmcpComputerClient,
+    context: &str,
+) {
+    match timeout(SMCP_CONNECTION_CLOSE_TIMEOUT, client.disconnect()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => log::warn!("Error disconnecting {}: {}", context, e),
+        Err(_) => log::warn!(
+            "Timed out disconnecting {} after {:?}",
+            context,
+            SMCP_CONNECTION_CLOSE_TIMEOUT,
+        ),
+    }
 }
 
 /// Get current connection status
@@ -197,7 +253,7 @@ pub async fn get_connection_status(
 
 /// Active connection state held in AppState
 pub struct ConnectionState {
-    pub client: std::sync::Arc<smcp_computer::socketio_client::SmcpComputerClient>,
+    pub client: smcp_computer::socketio_client::SmcpComputerClient,
     pub profile_name: String,
     pub url: String,
     pub office_id: String,

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -171,7 +171,7 @@ pub async fn disconnect_smcp(state: State<'_, AppState>) -> Result<(), String> {
     disconnect_smcp_core(&state).await
 }
 
-pub async fn disconnect_smcp_core(state: &AppState) -> Result<(), String> {
+async fn disconnect_smcp_core(state: &AppState) -> Result<(), String> {
     log::info!("Disconnecting from SMCP server");
 
     let existing_connection = {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,7 @@ pub mod commands;
 pub mod services;
 pub mod tray;
 
-use commands::connection::ConnectionState;
+use commands::connection::{close_smcp_connection, ConnectionState};
 use services::config::ConfigService;
 use services::logger::LogService;
 use services::manager_client::ManagerClient;
@@ -248,9 +248,12 @@ pub fn run() {
                 let state = app_handle.state::<AppState>();
                 tauri::async_runtime::block_on(async {
                     // Disconnect SMCP if connected
-                    let mut conn = state.connection.write().await;
-                    if let Some(connection) = conn.take() {
-                        let _ = connection.client.leave_office(&connection.office_id).await;
+                    let existing_connection = {
+                        let mut conn = state.connection.write().await;
+                        conn.take()
+                    };
+                    if let Some(connection) = existing_connection {
+                        close_smcp_connection(connection).await;
                     }
                     // Stop all MCP servers
                     let lock = state.manager.read().await;

--- a/src-tauri/tests/smcp_connection_lifecycle_test.rs
+++ b/src-tauri/tests/smcp_connection_lifecycle_test.rs
@@ -167,6 +167,18 @@ async fn close_smcp_connection_closes_underlying_socket_after_leaving_office() {
         || stats.active() == 0 && stats.disconnected() == 1,
     )
     .await;
+
+    sleep(Duration::from_millis(250)).await;
+    assert_eq!(
+        stats.active(),
+        0,
+        "SMCP socket should remain disconnected after cleanup"
+    );
+    assert_eq!(
+        stats.disconnected(),
+        1,
+        "SMCP cleanup should not trigger a reconnect cycle"
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/tests/smcp_connection_lifecycle_test.rs
+++ b/src-tauri/tests/smcp_connection_lifecycle_test.rs
@@ -1,0 +1,318 @@
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use http_body_util::Full;
+use hyper::body::Bytes;
+use smcp_computer::mcp_clients::manager::MCPServerManager;
+use smcp_computer::mcp_clients::model::MCPServerInput;
+use smcp_computer::socketio_client::SmcpComputerClient;
+use socketioxide::extract::{AckSender, SocketRef};
+use socketioxide::SocketIo;
+use tfrobot_client_lib::commands::connection::{
+    close_smcp_connection, connect_smcp_core, ConnectionProfile, ConnectionState,
+};
+use tokio::net::TcpListener;
+use tokio::sync::RwLock;
+use tokio::time::{sleep, Duration};
+use tower::service_fn;
+use tower::Layer;
+
+#[allow(dead_code)]
+mod common;
+
+const SERVER_JOIN_OFFICE: &str = "server:join_office";
+const SERVER_LEAVE_OFFICE: &str = "server:leave_office";
+
+#[derive(Default)]
+struct SocketStats {
+    active: AtomicUsize,
+    connected: AtomicUsize,
+    disconnected: AtomicUsize,
+    leave_events: AtomicUsize,
+}
+
+impl SocketStats {
+    fn active(&self) -> usize {
+        self.active.load(Ordering::SeqCst)
+    }
+
+    fn connected(&self) -> usize {
+        self.connected.load(Ordering::SeqCst)
+    }
+
+    fn disconnected(&self) -> usize {
+        self.disconnected.load(Ordering::SeqCst)
+    }
+
+    fn leave_events(&self) -> usize {
+        self.leave_events.load(Ordering::SeqCst)
+    }
+}
+
+async fn start_smcp_socket_server() -> (String, Arc<SocketStats>) {
+    let stats = Arc::new(SocketStats::default());
+    let (socket_layer, io) = SocketIo::new_layer();
+
+    let connect_stats = stats.clone();
+    io.ns("/smcp", move |socket: SocketRef| {
+        connect_stats.active.fetch_add(1, Ordering::SeqCst);
+        connect_stats.connected.fetch_add(1, Ordering::SeqCst);
+
+        socket.on(SERVER_JOIN_OFFICE, |ack: AckSender| {
+            let _ = ack.send(&(true, Option::<String>::None));
+        });
+
+        let leave_stats = connect_stats.clone();
+        socket.on(SERVER_LEAVE_OFFICE, move || {
+            leave_stats.leave_events.fetch_add(1, Ordering::SeqCst);
+        });
+
+        let disconnect_stats = connect_stats.clone();
+        socket.on_disconnect(move || {
+            disconnect_stats.active.fetch_sub(1, Ordering::SeqCst);
+            disconnect_stats.disconnected.fetch_add(1, Ordering::SeqCst);
+        });
+    });
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let url = format!("http://{}", listener.local_addr().expect("local_addr"));
+
+    tokio::spawn(async move {
+        let fallback = service_fn(|_req: hyper::Request<hyper::body::Incoming>| async {
+            Ok::<_, Infallible>(
+                hyper::Response::builder()
+                    .status(hyper::StatusCode::NOT_FOUND)
+                    .body(Full::<Bytes>::from("not found"))
+                    .unwrap(),
+            )
+        });
+        let service = socket_layer.layer(fallback);
+
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            let service = service.clone();
+            tokio::spawn(async move {
+                let stream = hyper_util::rt::TokioIo::new(stream);
+                let service = hyper_util::service::TowerToHyperService::new(service);
+                let _ = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(stream, service)
+                    .with_upgrades()
+                    .await;
+            });
+        }
+    });
+
+    (url, stats)
+}
+
+async fn wait_for(timeout_message: &str, predicate: impl Fn() -> bool) {
+    for _ in 0..40 {
+        if predicate() {
+            return;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    panic!("{timeout_message}");
+}
+
+#[tokio::test]
+async fn close_smcp_connection_closes_underlying_socket_after_leaving_office() {
+    let (server_url, stats) = start_smcp_socket_server().await;
+    let manager = Arc::new(RwLock::new(Some(MCPServerManager::new())));
+    let inputs: Arc<RwLock<HashMap<String, MCPServerInput>>> =
+        Arc::new(RwLock::new(HashMap::new()));
+
+    let client = SmcpComputerClient::new(
+        &server_url,
+        manager,
+        "lifecycle-test-computer".to_string(),
+        None,
+        inputs,
+        None,
+    )
+    .await
+    .expect("connect smcp client");
+
+    client
+        .join_office("lifecycle-office")
+        .await
+        .expect("join office");
+
+    wait_for("server never observed the SMCP socket connection", || {
+        stats.active() == 1 && stats.connected() == 1
+    })
+    .await;
+
+    close_smcp_connection(ConnectionState {
+        client,
+        profile_name: "lifecycle-profile".to_string(),
+        url: server_url,
+        office_id: "lifecycle-office".to_string(),
+        computer_name: "lifecycle-test-computer".to_string(),
+        connected_at: chrono::Utc::now(),
+    })
+    .await;
+
+    wait_for("server never observed the leave_office event", || {
+        stats.leave_events() == 1
+    })
+    .await;
+
+    wait_for(
+        "SMCP cleanup did not close the underlying Socket.IO connection",
+        || stats.active() == 0 && stats.disconnected() == 1,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn failed_profile_switch_keeps_existing_smcp_connection() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = common::create_test_app_state(tmp.path());
+    let (server_url, stats) = start_smcp_socket_server().await;
+    let manager = state.manager.clone();
+    let inputs = state.inputs.clone();
+
+    let client = SmcpComputerClient::new(
+        &server_url,
+        manager,
+        "existing-computer".to_string(),
+        None,
+        inputs,
+        None,
+    )
+    .await
+    .expect("connect existing smcp client");
+
+    client
+        .join_office("existing-office")
+        .await
+        .expect("join existing office");
+
+    wait_for("server never observed the existing SMCP socket", || {
+        stats.active() == 1 && stats.connected() == 1
+    })
+    .await;
+
+    {
+        let mut conn = state.connection.write().await;
+        *conn = Some(ConnectionState {
+            client,
+            profile_name: "existing-profile".to_string(),
+            url: server_url,
+            office_id: "existing-office".to_string(),
+            computer_name: "existing-computer".to_string(),
+            connected_at: chrono::Utc::now(),
+        });
+    }
+
+    let err = connect_smcp_core(&state, "missing-profile".to_string())
+        .await
+        .expect_err("missing profile should fail");
+    assert_eq!(err, "Profile not found: missing-profile");
+
+    let conn = state.connection.read().await;
+    let connection = conn
+        .as_ref()
+        .expect("existing connection should be preserved");
+    assert_eq!(connection.profile_name, "existing-profile");
+    drop(conn);
+
+    assert_eq!(stats.active(), 1);
+    assert_eq!(stats.disconnected(), 0);
+
+    let existing_connection = {
+        let mut conn = state.connection.write().await;
+        conn.take()
+    };
+    if let Some(connection) = existing_connection {
+        close_smcp_connection(connection).await;
+    }
+}
+
+#[tokio::test]
+async fn successful_profile_switch_closes_previous_smcp_connection() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = common::create_test_app_state(tmp.path());
+    let (old_server_url, old_stats) = start_smcp_socket_server().await;
+    let (new_server_url, new_stats) = start_smcp_socket_server().await;
+
+    let old_client = SmcpComputerClient::new(
+        &old_server_url,
+        state.manager.clone(),
+        "old-computer".to_string(),
+        None,
+        state.inputs.clone(),
+        None,
+    )
+    .await
+    .expect("connect old smcp client");
+
+    old_client
+        .join_office("old-office")
+        .await
+        .expect("join old office");
+
+    wait_for("server never observed the old SMCP socket", || {
+        old_stats.active() == 1 && old_stats.connected() == 1
+    })
+    .await;
+
+    {
+        let mut conn = state.connection.write().await;
+        *conn = Some(ConnectionState {
+            client: old_client,
+            profile_name: "old-profile".to_string(),
+            url: old_server_url,
+            office_id: "old-office".to_string(),
+            computer_name: "old-computer".to_string(),
+            connected_at: chrono::Utc::now(),
+        });
+    }
+
+    state
+        .config
+        .save_profiles(&[ConnectionProfile {
+            name: "new-profile".to_string(),
+            url: new_server_url.clone(),
+            namespace: "/smcp".to_string(),
+            office_id: "new-office".to_string(),
+            computer_name: "new-computer".to_string(),
+            api_key_ref: None,
+            headers: HashMap::new(),
+            auto_connect: true,
+            auto_reconnect: true,
+        }])
+        .expect("save profiles");
+
+    connect_smcp_core(&state, "new-profile".to_string())
+        .await
+        .expect("connect new profile");
+
+    wait_for("server never observed the new SMCP socket", || {
+        new_stats.active() == 1 && new_stats.connected() == 1
+    })
+    .await;
+    wait_for("old SMCP connection was not closed after switch", || {
+        old_stats.leave_events() == 1 && old_stats.active() == 0 && old_stats.disconnected() == 1
+    })
+    .await;
+
+    let conn = state.connection.read().await;
+    let connection = conn.as_ref().expect("new connection should be retained");
+    assert_eq!(connection.profile_name, "new-profile");
+    assert_eq!(connection.office_id, "new-office");
+    drop(conn);
+
+    let new_connection = {
+        let mut conn = state.connection.write().await;
+        conn.take()
+    };
+    if let Some(connection) = new_connection {
+        close_smcp_connection(connection).await;
+    }
+}

--- a/src-tauri/tests/smcp_handshake_config_test.rs
+++ b/src-tauri/tests/smcp_handshake_config_test.rs
@@ -1,17 +1,17 @@
-//! 验收测试：smcp-computer 0.1.15 握手配置化（TFRM-16 子项）
+//! 验收测试：smcp-computer 0.2.2 握手配置化（TFRM-16 子项）
 //!
 //! 本文件验证 rust-sdk PR 的实现是否符合 `docs/proposals/tfrm-16-rust-sdk-handshake-config.md` 建议。
 //!
 //! # 运行前提
 //!
-//! 1. rust-sdk 已发布 `smcp-computer` v0.1.15（含 `SmcpComputerClientBuilder` 与默认 `access_token` header）。
-//! 2. `src-tauri/Cargo.toml` 已将 `smcp-computer` 版本升级至 `0.1.15`。
+//! 1. rust-sdk 已发布 `smcp-computer` v0.2.2（含 `SmcpComputerClientBuilder` 与默认 `access_token` header）。
+//! 2. `src-tauri/Cargo.toml` 已将 `smcp-computer` 版本升级至 `0.2.2`。
 //! 3. 通过 feature flag 显式启用本文件：
 //!    ```bash
-//!    cargo test --test smcp_handshake_config_test --features verify-smcp-0-1-15
+//!    cargo test --test smcp_handshake_config_test --features verify-smcp-0-2-2
 //!    ```
 //!
-//! 在版本升级前，整个文件被 `#![cfg(feature = "verify-smcp-0-1-15")]` 门控，
+//! 在版本升级前，整个文件被 `#![cfg(feature = "verify-smcp-0-2-2")]` 门控，
 //! 不参与编译，不会影响现有 CI。
 //!
 //! # 验收策略
@@ -25,7 +25,7 @@
 //! 客户端的 `connect()` 会返回 `Err`（预期）；我们断言**捕获到的 headers** 是否符合预期。
 //! 这样无需引入 `socketioxide` 等重量依赖，也足以验证"上游 WS upgrade 携带什么 header / 连接到什么 namespace"。
 
-#![cfg(feature = "verify-smcp-0-1-15")]
+#![cfg(feature = "verify-smcp-0-2-2")]
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -159,7 +159,7 @@ async fn test_default_auth_header_is_access_token() {
     assert_eq!(
         captured.headers.get("access_token").map(String::as_str),
         Some("test-secret-123"),
-        "默认鉴权 header 应为 access_token（0.1.15 新默认）。实际 headers: {:?}",
+        "默认鉴权 header 应为 access_token（0.2.2 默认）。实际 headers: {:?}",
         captured.headers
     );
     assert!(
@@ -363,7 +363,7 @@ async fn test_backward_compat_new_uses_access_token_default() {
     let (manager, inputs) = empty_manager_and_inputs();
 
     // 走老的 `SmcpComputerClient::new()` 入口（tfrobot-client 当前的调用形态）。
-    // 升级到 0.1.15 后，此入口应内部委托给 Builder，默认 header 为 access_token。
+    // 升级到 0.2.2 后，此入口应内部委托给 Builder，默认 header 为 access_token。
     let result = SmcpComputerClient::new(
         &url,
         manager,
@@ -380,11 +380,11 @@ async fn test_backward_compat_new_uses_access_token_default() {
     assert_eq!(
         captured.headers.get("access_token").map(String::as_str),
         Some("compat-secret"),
-        "老的 new() 入口在 0.1.15 后也应走新默认 access_token。实际 headers: {:?}",
+        "老的 new() 入口在 0.2.2 后也应走新默认 access_token。实际 headers: {:?}",
         captured.headers
     );
     assert!(
         !captured.headers.contains_key("x-api-key"),
-        "0.1.15 后不应再有 x-api-key fallback"
+        "0.2.2 后不应再有 x-api-key fallback"
     );
 }


### PR DESCRIPTION
## Summary
- upgrade smcp-computer to 0.2.2 and adapt config construction
- close SMCP clients with leave_office + disconnect on disconnect, shutdown, and profile switches
- preserve the existing connection when switching profiles fails
- add Socket.IO lifecycle regression tests for close and profile switch behavior

## Tests
- cargo test --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml --features verify-smcp-0-1-15 --test smcp_handshake_config_test -- --nocapture